### PR TITLE
Rename Multihash::as_bytes() to to_bytes()

### DIFF
--- a/libp2p-peerstore/src/json_peerstore.rs
+++ b/libp2p-peerstore/src/json_peerstore.rs
@@ -68,13 +68,13 @@ impl<'a> Peerstore for &'a JsonPeerstore {
 
 	#[inline]
 	fn peer(self, peer_id: &PeerId) -> Option<Self::PeerAccess> {
-		let hash = peer_id.clone().as_bytes().to_base58();
+		let hash = peer_id.to_bytes().to_base58();
 		self.store.lock(hash.into()).map(JsonPeerstoreAccess)
 	}
 
 	#[inline]
 	fn peer_or_create(self, peer_id: &PeerId) -> Self::PeerAccess {
-		let hash = peer_id.clone().as_bytes().to_base58();
+		let hash = peer_id.to_bytes().to_base58();
 		JsonPeerstoreAccess(self.store.lock_or_create(hash.into()))
 	}
 

--- a/multihash/src/lib.rs
+++ b/multihash/src/lib.rs
@@ -130,11 +130,11 @@ impl FromHex for Multihash {
 
 impl Multihash {
 	/// Returns a byte vec representing the encoded multihash
-	pub fn as_bytes(&mut self) -> Vec<u8> {
+	pub fn to_bytes(&self) -> Vec<u8> {
 		let mut v = Vec::new();
 		v.write_u64::<BigEndian>(self.code).expect("writing to a locally owned vec should never yield I/O errors");
 		v.write_u64::<BigEndian>(self.length).expect("writing to a locally owned vec should never yield I/O errors");
-		v.append(&mut self.digest);
+		v.extend_from_slice(&self.digest);
 		v
 	}
 
@@ -210,7 +210,7 @@ mod tests {
 		};
 		let expected_bytes = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 44, 38, 180, 107, 104, 255, 198, 143, 249, 155, 69, 60, 29, 48, 65, 52, 19, 66, 45, 112, 100, 131, 191, 160, 249, 138, 94, 136, 98, 102, 231, 174];
 
-		assert_eq!(hash.clone().as_bytes(), expected_bytes);
+		assert_eq!(hash.to_bytes(), expected_bytes);
 
 		assert_eq!(Multihash::decode_bytes(expected_bytes).unwrap(), hash);
 	}


### PR DESCRIPTION
To fit the Rust naming convention. Also no longer drains the input multihash, so we don't have to clone it.