### PR TITLE
Add a README and documentation for libp2p-tcp-transport

### DIFF
--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -36,7 +36,7 @@ use std::io::Error as IoError;
 use std::iter;
 use std::sync::Arc;
 use swarm::{Transport, ConnectionUpgrade};
-use tcp::Tcp;
+use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::length_delimited;
@@ -44,7 +44,7 @@ use untrusted::Input;
 
 fn main() {
     let mut core = Core::new().unwrap();
-    let tcp = Tcp::new(core.handle()).unwrap();
+    let tcp = TcpConfig::new(core.handle());
     
     let with_secio = tcp
         .with_upgrade(swarm::PlainText)

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -36,7 +36,7 @@ use std::io::Error as IoError;
 use std::iter;
 use std::sync::Arc;
 use swarm::{Transport, ConnectionUpgrade};
-use tcp::Tcp;
+use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::length_delimited;
@@ -44,7 +44,7 @@ use untrusted::Input;
 
 fn main() {
     let mut core = Core::new().unwrap();
-    let tcp = Tcp::new(core.handle()).unwrap();
+    let tcp = TcpConfig::new(core.handle());
 
     let with_secio = tcp
         .with_upgrade(swarm::PlainText)

--- a/libp2p-tcp-transport/README.md
+++ b/libp2p-tcp-transport/README.md
@@ -1,0 +1,27 @@
+# TCP transport
+
+Implementation of the libp2p `Transport` trait for TCP/IP.
+
+Uses [the *tokio* library](https://tokio.rs).
+
+## Usage
+
+Create [a tokio `Core`](https://docs.rs/tokio-core/0.1/tokio_core/reactor/struct.Core.html),
+then grab a handle by calling the `handle()` method on it, then create a `TcpConfig` and pass
+the handle.
+
+Example:
+
+```rust
+extern crate libp2p_tcp_transport;
+extern crate tokio_core;
+
+use libp2p_tcp_transport::TcpConfig;
+use tokio_core::reactor::Core;
+
+let mut core = Core::new().unwrap();
+let tcp = TcpConfig::new(core.handle());
+```
+
+The `TcpConfig` structs implements the `Transport` trait of the `swarm` library. See the
+documentation of `swarm` and of libp2p in general to learn how to use the `Transport` trait.


### PR DESCRIPTION
#51 for tcp-transport

Also:
- Renames `Tcp` to `TcpConfig` for clarity.
- `TcpConfig::new` no longer returns a `Result` because it no longer make sense now that the tokio reactor is passed externally.