### PR TITLE
Remove or_upgrade and let users build OrUpgrade manually

### DIFF
--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -28,7 +28,7 @@ extern crate tokio_io;
 
 use futures::future::{Future, IntoFuture, loop_fn, Loop};
 use futures::{Stream, Sink};
-use swarm::{Transport, SimpleProtocol};
+use swarm::{Transport, UpgradeExt, SimpleProtocol};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::codec::length_delimited;
@@ -43,15 +43,20 @@ fn main() {
 
         // On top of TCP/IP, we will use either the plaintext protocol or the secio protocol,
         // depending on which one the remote supports.
-        .with_upgrade(swarm::PlainTextConfig)
-        .or_upgrade({
-            let private_key = include_bytes!("test-private-key.pk8");
-            let public_key = include_bytes!("test-public-key.der").to_vec();
-            secio::SecioConfig {
-                key: secio::SecioKeyPair::rsa_from_pkcs8(private_key, public_key).unwrap(),
-            }
+        .with_upgrade({
+            let plain_text = swarm::PlainTextConfig;
+
+            let secio = {
+                let private_key = include_bytes!("test-private-key.pk8");
+                let public_key = include_bytes!("test-public-key.der").to_vec();
+                secio::SecioConfig {
+                    key: secio::SecioKeyPair::rsa_from_pkcs8(private_key, public_key).unwrap(),
+                }
+            };
+
+            plain_text.or_upgrade(secio)
         })
-        
+
         // On top of plaintext or secio, we use the "echo" protocol, which is a custom protocol
         // just for this example.
         // For this purpose, we create a `SimpleProtocol` struct.

--- a/libp2p-swarm/src/lib.rs
+++ b/libp2p-swarm/src/lib.rs
@@ -181,4 +181,4 @@ pub use self::connection_reuse::ConnectionReuse;
 pub use self::multiaddr::Multiaddr;
 pub use self::muxing::StreamMuxer;
 pub use self::transport::{ConnectionUpgrade, PlainTextConfig, Transport, UpgradedNode, OrUpgrade};
-pub use self::transport::{Endpoint, SimpleProtocol, MuxedTransport};
+pub use self::transport::{Endpoint, SimpleProtocol, MuxedTransport, UpgradeExt};


### PR DESCRIPTION
Removes the `UpgradedNode::or_upgrade` method method, because it is contrary to good API practices.
Instead the user is now supposed to build a `OrUpgrade` object manually. This is slightly more cumbersome for now, and may be improved in the future.

The other reason for this change is that I couldn't think of a design for the future p2p-circuit protocol (which is a key element of the API design) that could use the current API. Using p2p-circuit will most likely require having an equivalent to `OrUpgrade` specifically for it.
