### PR TITLE
Implement the ls command for multistream-select

### DIFF
--- a/multistream-select/Cargo.toml
+++ b/multistream-select/Cargo.toml
@@ -8,6 +8,7 @@ bytes = "0.4"
 futures = { version = "0.1" }
 smallvec = "0.5"
 tokio-io = "0.1"
+varint = { path = "../varint-rs" }
 
 [dev-dependencies]
 tokio-core = "0.1"

--- a/multistream-select/src/lib.rs
+++ b/multistream-select/src/lib.rs
@@ -122,6 +122,7 @@ extern crate bytes;
 extern crate futures;
 extern crate smallvec;
 extern crate tokio_io;
+extern crate varint;
 
 mod dialer_select;
 mod error;

--- a/multistream-select/src/protocol/error.rs
+++ b/multistream-select/src/protocol/error.rs
@@ -23,6 +23,7 @@
 use std::error;
 use std::fmt;
 use std::io::Error as IoError;
+use varint::Error as VarIntError;
 
 /// Error at the multistream-select layer of communication.
 #[derive(Debug)]
@@ -38,12 +39,23 @@ pub enum MultistreamSelectError {
 
 	/// Protocol names must always start with `/`, otherwise this error is returned.
 	WrongProtocolName,
+
+	/// Failure to parse variable-length integer.
+	// TODO: we don't include the actual error, because that would remove Send from the enum
+	VarIntParseError,
 }
 
 impl From<IoError> for MultistreamSelectError {
 	#[inline]
 	fn from(err: IoError) -> MultistreamSelectError {
 		MultistreamSelectError::IoError(err)
+	}
+}
+
+impl From<VarIntError> for MultistreamSelectError {
+	#[inline]
+	fn from(_err: VarIntError) -> MultistreamSelectError {
+		MultistreamSelectError::VarIntParseError
 	}
 }
 
@@ -62,6 +74,9 @@ impl error::Error for MultistreamSelectError {
 			},
 			MultistreamSelectError::WrongProtocolName => {
 				"protocol names must always start with `/`, otherwise this error is returned"
+			},
+			MultistreamSelectError::VarIntParseError => {
+				"failure to parse variable-length integer"
 			},
 		}
 	}

--- a/multistream-select/src/tests.rs
+++ b/multistream-select/src/tests.rs
@@ -147,7 +147,6 @@ fn no_protocol_found() {
 }
 
 #[test]
-#[ignore] // TODO: not yet implemented in the listener
 fn select_proto_parallel() {
 	let mut core = Core::new().unwrap();
 


### PR DESCRIPTION
Now that `varint` is available, we can remove this `unimplemented!()` and unignore the test.