### PR TITLE
Allow customizing the address in the examples, plus minor improvements

### DIFF
--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -88,7 +88,11 @@ fn main() {
     // We use it to dial the address.
     let dialer = transport
         .dial_and_listen(swarm::Multiaddr::new(&target_addr).expect("invalid multiaddr"))
-        .unwrap_or_else(|_| panic!("unsupported multiaddr protocol ; should never happen"))
+        // If the multiaddr protocol exists but is not supported, then we get an error containing
+        // the transport and the original multiaddress. Therefore we cannot directly use `unwrap()`
+        // or `expect()`, but have to add a `map_err()` beforehand.
+        .map_err(|(_, addr)| addr).expect("unsupported multiaddr")
+
         .and_then(|(incoming, echo)| {
             // `echo` is what the closure used when initializing "echo" returns.
             // Consequently, please note that the `send` method is available only because the type

--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -29,12 +29,16 @@ extern crate tokio_io;
 
 use bytes::BytesMut;
 use futures::{Future, Sink, Stream};
+use std::env;
 use swarm::{UpgradeExt, SimpleProtocol, Transport};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::codec::length_delimited;
 
 fn main() {
+    // Determine which address to dial.
+    let target_addr = env::args().nth(1).unwrap_or("/ip4/127.0.0.1/tcp/10333".to_owned());
+
     // We start by building the tokio engine that will run all the sockets.
     let mut core = Core::new().unwrap();
 
@@ -58,10 +62,14 @@ fn main() {
             plain_text.or_upgrade(secio)
         })
 
-        .with_upgrade(multiplex::MultiplexConfig);
-    let transport: swarm::ConnectionReuse<_, _> = transport.into();
+        // On top of plaintext or secio, we will use the multiplex protocol.
+        .with_upgrade(multiplex::MultiplexConfig)
+        // The object returned by the call to `with_upgrade(MultiplexConfig)` can't be used as a
+        // `Transport` because the output of the upgrade is not a stream but a controller for
+        // muxing. We have to explicitly call `into_connection_reuse()` in order to turn this into
+        // a `Transport`.
+        .into_connection_reuse()
 
-    let transport = transport
         // On top of plaintext or secio, we use the "echo" protocol, which is a custom protocol
         // just for this example.
         // For this purpose, we create a `SimpleProtocol` struct.
@@ -77,9 +85,9 @@ fn main() {
     // incoming connections, and that will automatically apply all the selected protocols on top
     // of any opened stream.
 
-    // We use it to dial `/ip4/127.0.0.1/tcp/10333`.
+    // We use it to dial the address.
     let dialer = transport
-        .dial_and_listen(swarm::Multiaddr::new("/ip4/127.0.0.1/tcp/10333").unwrap())
+        .dial_and_listen(swarm::Multiaddr::new(&target_addr).expect("invalid multiaddr"))
         .unwrap_or_else(|_| panic!("unsupported multiaddr protocol ; should never happen"))
         .and_then(|(incoming, echo)| {
             // `echo` is what the closure used when initializing "echo" returns.

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -88,7 +88,10 @@ fn main() {
     // We use it to listen on the address.
     let (listener, address) = transport
         .listen_on(swarm::Multiaddr::new(&listen_addr).expect("invalid multiaddr"))
-        .unwrap_or_else(|_| panic!("unsupported multiaddr protocol ; should never happen"));
+        // If the multiaddr protocol exists but is not supported, then we get an error containing
+        // the transport and the original multiaddress. Therefore we cannot directly use `unwrap()`
+        // or `expect()`, but have to add a `map_err()` beforehand.
+        .map_err(|(_, addr)| addr).expect("unsupported multiaddr");
     println!("Now listening on {:?}", address);
 
     let future = listener

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -23,17 +23,22 @@ extern crate futures;
 extern crate libp2p_secio as secio;
 extern crate libp2p_swarm as swarm;
 extern crate libp2p_tcp_transport as tcp;
+extern crate multiplex;
 extern crate tokio_core;
 extern crate tokio_io;
 
 use futures::future::{Future, IntoFuture, loop_fn, Loop};
 use futures::{Stream, Sink};
+use std::env;
 use swarm::{Transport, UpgradeExt, SimpleProtocol};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::codec::length_delimited;
 
 fn main() {
+    // Determine which address to listen to.
+    let listen_addr = env::args().nth(1).unwrap_or("/ip4/0.0.0.0/tcp/10333".to_owned());
+
     // We start by building the tokio engine that will run all the sockets.
     let mut core = Core::new().unwrap();
 
@@ -57,8 +62,16 @@ fn main() {
             plain_text.or_upgrade(secio)
         })
 
-        // On top of plaintext or secio, we use the "echo" protocol, which is a custom protocol
-        // just for this example.
+        // On top of plaintext or secio, we will use the multiplex protocol.
+        .with_upgrade(multiplex::MultiplexConfig)
+        // The object returned by the call to `with_upgrade(MultiplexConfig)` can't be used as a
+        // `Transport` because the output of the upgrade is not a stream but a controller for
+        // muxing. We have to explicitly call `into_connection_reuse()` in order to turn this into
+        // a `Transport`.
+        .into_connection_reuse()
+
+        // On top of both mutiplex and plaintext/secio, we use the "echo" protocol, which is a
+        // custom protocol just for this example.
         // For this purpose, we create a `SimpleProtocol` struct.
         .with_upgrade(SimpleProtocol::new("/echo/1.0.0", |socket| {
             // This closure is called whenever a stream using the "echo" protocol has been
@@ -72,10 +85,13 @@ fn main() {
     // incoming connections, and that will automatically apply all the selected protocols on top
     // of any opened stream.
 
-    // We use it to listen on `/ip4/127.0.0.1/tcp/10333`.
-    let future = transport.listen_on(swarm::Multiaddr::new("/ip4/0.0.0.0/tcp/10333").unwrap())
-        .unwrap_or_else(|_| panic!("unsupported multiaddr protocol ; should never happen")).0
+    // We use it to listen on the address.
+    let (listener, address) = transport
+        .listen_on(swarm::Multiaddr::new(&listen_addr).expect("invalid multiaddr"))
+        .unwrap_or_else(|_| panic!("unsupported multiaddr protocol ; should never happen"));
+    println!("Now listening on {:?}", address);
 
+    let future = listener
         .filter_map(|(socket, client_addr)| {
             let client_addr = client_addr.to_string();
 

--- a/libp2p-swarm/src/transport.rs
+++ b/libp2p-swarm/src/transport.rs
@@ -30,6 +30,7 @@
 //! in a complex chain of protocols negotiation.
 
 use bytes::Bytes;
+use connection_reuse::ConnectionReuse;
 use futures::{Async, Poll, Stream};
 use futures::future::{self, FromErr, Future, FutureResult, IntoFuture};
 use multiaddr::Multiaddr;
@@ -706,6 +707,13 @@ where
 	T: Transport + 'a,
 	C: ConnectionUpgrade<T::RawConn> + 'a,
 {
+	/// Turns this upgraded node into a `ConnectionReuse`. If the `Output` implements the
+	/// `StreamMuxer` trait, the returned object will implement `Transport` and `MuxedTransport`.
+	#[inline]
+	pub fn into_connection_reuse(self) -> ConnectionReuse<T, C> {
+		From::from(self)
+	}
+
 	/// Tries to dial on the `Multiaddr` using the transport that was passed to `new`, then upgrade
 	/// the connection.
 	///


### PR DESCRIPTION
Allows passing the multiaddr as the first parameter to the examples.
Also adds documentation, and the `into_connection_reuse()` method on `UpgradedNode`.