### PR TITLE
move to rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p"
-edition = "2018"
+edition = "2021"
 description = "Peer-to-peer networking library"
 version = "0.40.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-core"
-edition = "2018"
+edition = "2021"
 description = "Core traits and structs of libp2p"
 version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-metrics"
-edition = "2018"
+edition = "2021"
 description = "Metrics for libp2p"
 version = "0.1.0"
 authors = ["Max Inden <mail@max-inden.de>"]

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bytes = "1"

--- a/misc/peer-id-generator/Cargo.toml
+++ b/misc/peer-id-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peer-id-generator"
-edition = "2018"
+edition = "2021"
 version = "0.1.0"
 description = "Generate peer ids that are prefixed with a specific string"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-mplex"
-edition = "2018"
+edition = "2021"
 description = "Mplex multiplexing protocol for libp2p"
 version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-yamux"
-edition = "2018"
+edition = "2021"
 description = "Yamux multiplexing protocol for libp2p"
 version = "0.34.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-floodsub"
-edition = "2018"
+edition = "2021"
 description = "Floodsub protocol for libp2p"
 version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-gossipsub"
-edition = "2018"
+edition = "2021"
 description = "Gossipsub protocol for libp2p"
 version = "0.33.0"
 authors = ["Age Manning <Age@AgeManning.com>"]

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-identify"
-edition = "2018"
+edition = "2021"
 description = "Nodes identifcation protocol for libp2p"
 version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-kad"
-edition = "2018"
+edition = "2021"
 description = "Kademlia protocol for libp2p"
 version = "0.32.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-mdns"
-edition = "2018"
+edition = "2021"
 version = "0.32.0"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-ping"
-edition = "2018"
+edition = "2021"
 description = "Ping protocol for libp2p"
 version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-relay"
-edition = "2018"
+edition = "2021"
 description = "Communications relaying for libp2p"
 version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-rendezvous"
-edition = "2018"
+edition = "2021"
 description = "Rendezvous protocol for libp2p"
 version = "0.1.0"
 authors = ["The COMIT guys <hello@comit.network>"]

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-request-response"
-edition = "2018"
+edition = "2021"
 description = "Generic Request/Response Protocols"
 version = "0.13.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -46,7 +46,7 @@
 //!        name = "rust-libp2p-tutorial"
 //!        version = "0.1.0"
 //!        authors = ["Max Inden <mail@max-inden.de>"]
-//!        edition = "2018"
+//!        edition = "2021"
 //!
 //!    [dependencies]
 //!        libp2p = "<insert-current-version-here>"

--- a/swarm-derive/Cargo.toml
+++ b/swarm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-swarm-derive"
-edition = "2018"
+edition = "2021"
 description = "Procedural macros of libp2p-core"
 version = "0.25.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-swarm"
-edition = "2018"
+edition = "2021"
 description = "The libp2p swarm"
 version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/deflate/Cargo.toml
+++ b/transports/deflate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-deflate"
-edition = "2018"
+edition = "2021"
 description = "Deflate encryption protocol for libp2p"
 version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-dns"
-edition = "2018"
+edition = "2021"
 description = "DNS transport implementation for libp2p"
 version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.33.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bytes = "1"

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-plaintext"
-edition = "2018"
+edition = "2021"
 description = "Plaintext encryption dummy protocol for libp2p"
 version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/pnet/Cargo.toml
+++ b/transports/pnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-pnet"
-edition = "2018"
+edition = "2021"
 description = "Private swarm support for libp2p"
 version = "0.22.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-tcp"
-edition = "2018"
+edition = "2021"
 description = "TCP/IP transport protocol for libp2p"
 version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-uds"
-edition = "2018"
+edition = "2021"
 description = "Unix domain sockets transport for libp2p"
 version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-wasm-ext"
 version = "0.30.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Allows passing in an external transport in a WASM environment"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-websocket"
-edition = "2018"
+edition = "2021"
 description = "WebSocket transport for libp2p"
 version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]


### PR DESCRIPTION
Confirmed to build locally on Ubuntu 20.04.3 LTS:
```
rustc 1.56.1 (59eed8a2a 2021-11-01)
rustc 1.58.0-nightly (e90c5fbbc 2021-11-12)
```